### PR TITLE
The CheckItOut module should suggest the Magento Composer Installer instead of requiring it

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,8 +4,7 @@
   "type": "magento-module",
   "description": "CheckItOut Magento extension",
   "require": {
-    "php": ">=5.4.0",
-    "magento-hackathon/magento-composer-installer": "dev-master"
+    "php": ">=5.4.0"
   },
   "require-dev": {
     "magento/core": "1.9.1.0",
@@ -14,6 +13,9 @@
     "ecomdev/mage-ci": "*",
     "satooshi/php-coveralls": "dev-master",
     "phpunit/phpcov": "*"
+  },
+  "suggest": {
+    "magento-hackathon/magento-composer-installer": "Allows to manage this package as a dependency"
   },
   "repositories": [
     {


### PR DESCRIPTION
When upgrading a Magento store from Magento 1.6.2.0 to 1.9.2.4, it turned out that the CheckItOut module needed upgrading, too, because of compatibility fixes that were made.

However, we were unable to, because the CheckItOut module requires the `dev-master` version of the Magento Composer Installer, but our project requires the latest `3.0` release of the Magento Composer Installer. This means that Composer was unable to find the right version of the Magento Composer Installer to use, and errored out with the message "Your requirements could not be resolved to an installable set of packages."

As long as this is the case, we are unable to use your module as a Composer package, but would like to do so.

Removing your `require`ment of the Installer solves our problem, and for various other reasons, ([see the official docs for details](https://github.com/Cotya/magento-composer-installer/blob/3.0/doc/FAQ.md#should-my-module-require-the-installer)), `suggest`ing the Magento Composer Installer is better than `require`-ing it. So I made a fork and this PR, for the benefit of ourselves and of others.
