### PR TITLE
Fix issue with coupon codes being removed at the checkout

### DIFF
--- a/RELEASE_NOTES.txt
+++ b/RELEASE_NOTES.txt
@@ -1,3 +1,8 @@
+CheckItOut 1.5.14
+=================
+Bug Fixes
+- Fix issue that caused coupon codes to be wiped when updating the billing address
+
 CheckItOut 1.5.13
 =================
 Improvements

--- a/src/app/code/community/EcomDev/CheckItOut/Model/Type/Onepage.php
+++ b/src/app/code/community/EcomDev/CheckItOut/Model/Type/Onepage.php
@@ -221,6 +221,16 @@ class EcomDev_CheckItOut_Model_Type_Onepage
             $property->setValue($this->getQuote(), true);
         }
 
+        // The billing address has no items associated with it. If we check use_for_shipping
+        // the entire billing address, including the cache with no items, is copied to the
+        // shipping address. This results in the coupon code being removed when it attempts
+        // validate it later in this request.
+        if (!$this->getQuote()->isVirtual() && !empty($data['use_for_shipping']) ) {
+            $billing = $this->getQuote()->getBillingAddress();
+            $billing->unsetData('cached_items_all');
+            $billing->unsetData('cached_items_nominal');
+            $billing->unsetData('cached_items_nonnominal');
+        }
         $result = $this->_getDependency()->saveBilling($data, $customerAddressId);
 
         if (isset($property)) {

--- a/src/app/code/community/EcomDev/CheckItOut/etc/config.xml
+++ b/src/app/code/community/EcomDev/CheckItOut/etc/config.xml
@@ -21,7 +21,7 @@
     <modules>
         <EcomDev_CheckItOut>
             <version>0.1.1</version>
-            <codeVersion>1.5.12</codeVersion>
+            <codeVersion>1.5.14</codeVersion>
         </EcomDev_CheckItOut>
     </modules>
     <global>


### PR DESCRIPTION
When the billing address "use_for_shipping" flag was checked, editing
the billing address would wipe the coupon code. This was caused by the
item cache fields being saved on the billing address, being copied into
the shipping address, which would result in the coupon code not being
set during the collection of totals.

To resolve the issue we unset the item cache fields on the address
object, which allows the coupon code to be set correctly after editing
the billing address.

It should be noted that this solution comes from the suggestion in
issue #11 