### PR TITLE
Do not disable form_key, needed for 1.9.3.3 / SUPEE-9767

### DIFF
--- a/src/skin/frontend/base/default/js/ecomdev/checkitout/steps/payment.js
+++ b/src/skin/frontend/base/default/js/ecomdev/checkitout/steps/payment.js
@@ -232,7 +232,9 @@ var Payment = Class.create(EcomDev.CheckItOut.Step, {
                     method = elements[i].value;
                 }
             } else {
-                elements[i].disabled = true;
+                if (elements[i].name != 'form_key') {
+                    elements[i].disabled = true;
+                }
             }
             elements[i].setAttribute('autocomplete','off');
         }


### PR DESCRIPTION
This fix will leave the hidden form_key field (introduced in Magento 1.9.3.3 / SUPEE-9767) in the payment block enabled, allowing a successful save of the payment methods