### PR TITLE
payment to check only visible input fields

### DIFF
--- a/src/skin/frontend/base/default/js/ecomdev/checkitout/steps/payment.js
+++ b/src/skin/frontend/base/default/js/ecomdev/checkitout/steps/payment.js
@@ -351,7 +351,7 @@ var Payment = Class.create(EcomDev.CheckItOut.Step, {
             fireAnEvent || document.body.fire('payment-method:switched', {method_code : method});
         }
 
-        if ((!form || form.select('select','input', 'textarea').length == 0)) {
+        if ((!form || form.select('select','input:not([type=hidden])', 'textarea').length == 0)) {
             this.handleChange({});
         }
 


### PR DESCRIPTION
with current implementation methods without with hidden input elements are acted the same as those with visible inputs. 

this PR makes it check only for visible inputs, so a method with for example two hidden inputs and no visible inputs can be saved by savePayment ajax request